### PR TITLE
Improve mobile layout responsiveness

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -96,3 +96,32 @@ code {
   background: #229954;
   transform: translateY(-2px);
 }
+
+@media (max-width: 768px) {
+  .app {
+    padding: 16px;
+  }
+
+  .load-prompt-modal {
+    padding: 30px 24px;
+  }
+}
+
+@media (max-width: 480px) {
+  .app {
+    padding: 12px;
+  }
+
+  .load-prompt-modal {
+    padding: 24px 18px;
+  }
+
+  .load-prompt-actions {
+    flex-direction: column;
+  }
+
+  .btn-start-fresh,
+  .btn-load-saved {
+    width: 100%;
+  }
+}

--- a/src/components/ConfigPanel.css
+++ b/src/components/ConfigPanel.css
@@ -210,3 +210,81 @@
 .btn-start:active {
   transform: translateY(0);
 }
+
+@media (max-width: 900px) {
+  .config-panel {
+    padding: 16px;
+  }
+
+  .config-section {
+    padding: 18px;
+  }
+}
+
+@media (max-width: 600px) {
+  .config-panel {
+    padding: 14px 12px 24px;
+  }
+
+  .config-panel h1 {
+    font-size: 26px;
+  }
+
+  .config-section {
+    padding: 16px;
+  }
+
+  .btn-sample-data {
+    width: 100%;
+  }
+
+  .court-item,
+  .player-item {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .player-item .skill-level {
+    justify-content: space-between;
+  }
+
+  .skill-input {
+    width: 100% !important;
+    max-width: 90px;
+  }
+
+  .add-court,
+  .add-player {
+    flex-direction: column;
+  }
+
+  .btn-add,
+  .btn-remove {
+    width: 100%;
+  }
+
+  .start-button-container {
+    margin-top: 24px;
+  }
+
+  .btn-start {
+    width: 100%;
+    padding: 14px 18px;
+    font-size: 16px;
+  }
+}
+
+@media (max-width: 420px) {
+  .config-panel h1 {
+    font-size: 24px;
+  }
+
+  .form-group label {
+    font-size: 14px;
+  }
+
+  .btn-start {
+    font-size: 15px;
+  }
+}

--- a/src/components/EditTournamentModal.css
+++ b/src/components/EditTournamentModal.css
@@ -390,3 +390,77 @@
     font-size: 14px;
   }
 }
+
+@media (max-width: 600px) {
+  .modal-overlay {
+    padding: 12px;
+  }
+
+  .modal-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .modal-tabs {
+    overflow-x: auto;
+    padding: 0 12px;
+  }
+
+  .modal-body {
+    padding: 18px 16px;
+  }
+
+  .player-edit-item {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .player-edit-item .skill-level {
+    justify-content: space-between;
+  }
+
+  .add-player-section {
+    flex-direction: column;
+  }
+
+  .add-player-section .skill-input {
+    width: 100%;
+    max-width: 90px;
+  }
+
+  .match-edit-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .match-edit-details {
+    flex-wrap: wrap;
+  }
+
+  .match-teams-edit {
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .player-select-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .btn-remove-player {
+    align-self: flex-end;
+  }
+
+  .modal-footer {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .btn-cancel-modal,
+  .btn-save-modal {
+    width: 100%;
+  }
+}

--- a/src/components/MatchCard.css
+++ b/src/components/MatchCard.css
@@ -244,3 +244,91 @@
 .btn-enter-score:hover {
   background: #2980b9;
 }
+
+@media (max-width: 640px) {
+  .match-card {
+    padding: 16px;
+  }
+
+  .match-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .match-time-court {
+    width: 100%;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .match-time,
+  .match-court {
+    font-size: 11px;
+  }
+
+  .match-winner {
+    align-self: flex-start;
+  }
+
+  .team {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .team-sets {
+    font-size: 20px;
+    align-self: flex-end;
+  }
+
+  .score-editor-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .score-save-cancel {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .btn-save,
+  .btn-cancel {
+    flex: 1;
+  }
+}
+
+@media (max-width: 480px) {
+  .match-card {
+    padding: 14px;
+  }
+
+  .team-sets {
+    font-size: 18px;
+  }
+
+  .set-input {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .set-label {
+    min-width: 40px;
+  }
+
+  .set-input input {
+    width: 48px;
+    font-size: 14px;
+  }
+
+  .score-save-cancel {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .btn-save,
+  .btn-cancel,
+  .btn-enter-score {
+    width: 100%;
+  }
+}

--- a/src/components/TournamentReport.css
+++ b/src/components/TournamentReport.css
@@ -247,3 +247,35 @@
     grid-template-columns: 1fr;
   }
 }
+
+@media (max-width: 600px) {
+  .tournament-report {
+    padding: 16px 12px 24px;
+  }
+
+  .report-section {
+    padding: 18px;
+  }
+
+  .summary-value {
+    font-size: 22px;
+  }
+
+  .fun-stat-card {
+    padding: 20px;
+  }
+}
+
+@media (max-width: 420px) {
+  .report-section {
+    padding: 16px;
+  }
+
+  .report-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .summary-value {
+    font-size: 20px;
+  }
+}

--- a/src/components/TournamentView.css
+++ b/src/components/TournamentView.css
@@ -318,7 +318,7 @@
 
 .matches-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: 20px;
 }
 
@@ -360,7 +360,7 @@
 
   .round-controls {
     width: 100%;
-    justify-content: stretch;
+    justify-content: space-between;
   }
 
   .btn-expand,
@@ -388,5 +388,81 @@
 
   .round-matches {
     padding: 15px;
+  }
+}
+
+@media (max-width: 600px) {
+  .tournament-view {
+    padding: 16px 12px 24px;
+  }
+
+  .tournament-header {
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .tournament-title {
+    text-align: left;
+  }
+
+  .header-actions {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .btn-back,
+  .btn-edit,
+  .btn-report {
+    width: 100%;
+  }
+
+  .controls-section {
+    gap: 16px;
+  }
+
+  .filter-section {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .round-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .round-header-right {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
+  .round-progress,
+  .round-badge {
+    margin-top: 6px;
+  }
+}
+
+@media (max-width: 480px) {
+  .round-header-left {
+    width: 100%;
+    gap: 10px;
+  }
+
+  .round-time,
+  .round-progress,
+  .round-badge {
+    width: 100%;
+    text-align: center;
+  }
+
+  .round-header-right {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .round-matches {
+    padding: 12px;
   }
 }


### PR DESCRIPTION
## Summary
- tighten global padding and modal button layout for small-screen devices
- add responsive stacking and width rules to configuration, tournament, and report views to prevent overflow
- update match card and edit modal styles for narrow viewports and touch-friendly controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e391beefdc832e97f52a94b91f42c3