### PR TITLE
Improve touch usability across the tournament UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,6 +4,10 @@
   box-sizing: border-box;
 }
 
+:root {
+  --touch-target-size: 44px;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
@@ -12,11 +16,22 @@ body {
   -moz-osx-font-smoothing: grayscale;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   min-height: 100vh;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .app {
   min-height: 100vh;
   padding: 20px;
+}
+
+button {
+  touch-action: manipulation;
+}
+
+button:focus-visible,
+.round-header:focus-visible {
+  outline: 3px solid rgba(52, 152, 219, 0.6);
+  outline-offset: 2px;
 }
 
 code {
@@ -123,5 +138,23 @@ code {
   .btn-start-fresh,
   .btn-load-saved {
     width: 100%;
+  }
+}
+
+@media (hover: none) and (pointer: coarse) {
+  button,
+  input,
+  select {
+    min-height: var(--touch-target-size);
+  }
+
+  input,
+  select {
+    font-size: 16px;
+  }
+
+  .btn-start-fresh,
+  .btn-load-saved {
+    font-size: 17px;
   }
 }

--- a/src/components/ConfigPanel.css
+++ b/src/components/ConfigPanel.css
@@ -26,6 +26,9 @@
   font-weight: 600;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   transition: all 0.3s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .btn-sample-data:hover {
@@ -160,8 +163,12 @@
   border: none;
   border-radius: 4px;
   cursor: pointer;
-  font-weight: 500;
+  font-size: 15px;
+  font-weight: 600;
   white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .btn-add:hover {
@@ -175,8 +182,11 @@
   border: none;
   border-radius: 4px;
   cursor: pointer;
-  font-size: 12px;
+  font-size: 14px;
   white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .btn-remove:hover {
@@ -199,6 +209,9 @@
   font-weight: 600;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   transition: all 0.3s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .btn-start:hover {
@@ -286,5 +299,38 @@
 
   .btn-start {
     font-size: 15px;
+  }
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .config-panel {
+    padding-bottom: 32px;
+  }
+
+  .form-group input[type="text"],
+  .form-group input[type="time"],
+  .form-group input[type="number"],
+  .form-group select,
+  .add-court input,
+  .add-player input,
+  .skill-input {
+    font-size: 16px;
+  }
+
+  .btn-sample-data,
+  .btn-add,
+  .btn-remove,
+  .btn-start {
+    font-size: 16px;
+  }
+
+  .court-item,
+  .player-item {
+    padding: 12px;
+  }
+
+  .btn-add,
+  .btn-remove {
+    min-width: var(--touch-target-size);
   }
 }

--- a/src/components/ConfigPanel.tsx
+++ b/src/components/ConfigPanel.tsx
@@ -110,7 +110,7 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({ onStartTournament }) => {
       <h1>🎾 Tennis Tournament Generator</h1>
 
       <div className="quick-start">
-        <button onClick={handleLoadSampleData} className="btn-sample-data">
+        <button type="button" onClick={handleLoadSampleData} className="btn-sample-data">
           🎯 Load Sample Data (Try it out!)
         </button>
       </div>
@@ -168,6 +168,9 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({ onStartTournament }) => {
             max="180"
             value={config.matchDuration}
             onChange={(e) => setConfig({ ...config, matchDuration: parseInt(e.target.value) || 60 })}
+            inputMode="numeric"
+            pattern="[0-9]*"
+            enterKeyHint="next"
           />
         </div>
 
@@ -211,7 +214,7 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({ onStartTournament }) => {
           {config.courts.map((court, idx) => (
             <div key={idx} className="court-item">
               <span>{court}</span>
-              <button onClick={() => handleRemoveCourt(idx)} className="btn-remove">
+              <button type="button" onClick={() => handleRemoveCourt(idx)} className="btn-remove">
                 Remove
               </button>
             </div>
@@ -223,9 +226,15 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({ onStartTournament }) => {
             placeholder="Court name"
             value={courtInput}
             onChange={(e) => setCourtInput(e.target.value)}
-            onKeyPress={(e) => e.key === 'Enter' && handleAddCourt()}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleAddCourt();
+              }
+            }}
+            enterKeyHint="done"
           />
-          <button onClick={handleAddCourt} className="btn-add">Add Court</button>
+          <button type="button" onClick={handleAddCourt} className="btn-add">Add Court</button>
         </div>
       </div>
 
@@ -249,9 +258,11 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({ onStartTournament }) => {
                   value={player.skillLevel || 5}
                   onChange={(e) => handleUpdatePlayer(player.id, 'skillLevel', parseInt(e.target.value) || 5)}
                   className="skill-input"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
                 />
               </div>
-              <button onClick={() => handleRemovePlayer(player.id)} className="btn-remove">
+              <button type="button" onClick={() => handleRemovePlayer(player.id)} className="btn-remove">
                 Remove
               </button>
             </div>
@@ -263,7 +274,13 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({ onStartTournament }) => {
             placeholder="Player name"
             value={newPlayerName}
             onChange={(e) => setNewPlayerName(e.target.value)}
-            onKeyPress={(e) => e.key === 'Enter' && handleAddPlayer()}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleAddPlayer();
+              }
+            }}
+            enterKeyHint="next"
           />
           <input
             type="number"
@@ -273,13 +290,15 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({ onStartTournament }) => {
             value={newPlayerSkill}
             onChange={(e) => setNewPlayerSkill(parseInt(e.target.value) || 5)}
             className="skill-input"
+            inputMode="numeric"
+            pattern="[0-9]*"
           />
-          <button onClick={handleAddPlayer} className="btn-add">Add Player</button>
+          <button type="button" onClick={handleAddPlayer} className="btn-add">Add Player</button>
         </div>
       </div>
 
       <div className="start-button-container">
-        <button onClick={handleStartTournament} className="btn-start">
+        <button type="button" onClick={handleStartTournament} className="btn-start">
           Generate Tournament
         </button>
       </div>

--- a/src/components/ConfigPanel.tsx
+++ b/src/components/ConfigPanel.tsx
@@ -227,7 +227,7 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({ onStartTournament }) => {
             value={courtInput}
             onChange={(e) => setCourtInput(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') {
+              if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
                 handleAddCourt();
               }
@@ -275,7 +275,7 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({ onStartTournament }) => {
             value={newPlayerName}
             onChange={(e) => setNewPlayerName(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') {
+              if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
                 handleAddPlayer();
               }

--- a/src/components/MatchCard.css
+++ b/src/components/MatchCard.css
@@ -162,6 +162,9 @@
   border-radius: 3px;
   cursor: pointer;
   font-size: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .btn-remove-set:hover {
@@ -330,5 +333,35 @@
   .btn-cancel,
   .btn-enter-score {
     width: 100%;
+  }
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .match-card:hover {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    transform: none;
+  }
+
+  .set-input {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .set-input input {
+    width: 64px;
+    font-size: 18px;
+  }
+
+  .btn-add-set,
+  .btn-save,
+  .btn-cancel,
+  .btn-enter-score {
+    font-size: 16px;
+  }
+
+  .btn-remove-set {
+    min-width: var(--touch-target-size);
+    min-height: var(--touch-target-size);
+    font-size: 20px;
   }
 }

--- a/src/components/MatchCard.tsx
+++ b/src/components/MatchCard.tsx
@@ -123,6 +123,9 @@ const MatchCard: React.FC<MatchCardProps> = ({ match, onUpdateMatch }) => {
                 max="7"
                 value={set.team1Games}
                 onChange={(e) => handleSetChange(idx, 'team1', parseInt(e.target.value) || 0)}
+                inputMode="numeric"
+                pattern="[0-9]*"
+                aria-label={`Games won by ${team1Names} in set ${idx + 1}`}
               />
               <span>-</span>
               <input
@@ -131,23 +134,31 @@ const MatchCard: React.FC<MatchCardProps> = ({ match, onUpdateMatch }) => {
                 max="7"
                 value={set.team2Games}
                 onChange={(e) => handleSetChange(idx, 'team2', parseInt(e.target.value) || 0)}
+                inputMode="numeric"
+                pattern="[0-9]*"
+                aria-label={`Games won by ${team2Names} in set ${idx + 1}`}
               />
               {sets.length > 1 && (
-                <button onClick={() => handleRemoveSet(idx)} className="btn-remove-set">
+                <button
+                  type="button"
+                  onClick={() => handleRemoveSet(idx)}
+                  className="btn-remove-set"
+                  aria-label={`Remove set ${idx + 1}`}
+                >
                   ✕
                 </button>
               )}
             </div>
           ))}
           <div className="score-editor-actions">
-            <button onClick={handleAddSet} className="btn-add-set">
+            <button type="button" onClick={handleAddSet} className="btn-add-set">
               + Add Set
             </button>
             <div className="score-save-cancel">
-              <button onClick={handleSave} className="btn-save">
+              <button type="button" onClick={handleSave} className="btn-save">
                 Save Score
               </button>
-              <button onClick={handleCancel} className="btn-cancel">
+              <button type="button" onClick={handleCancel} className="btn-cancel">
                 Cancel
               </button>
             </div>
@@ -157,7 +168,7 @@ const MatchCard: React.FC<MatchCardProps> = ({ match, onUpdateMatch }) => {
 
       {!isEditing && (
         <div className="match-actions">
-          <button onClick={handleStartEditing} className="btn-enter-score">
+          <button type="button" onClick={handleStartEditing} className="btn-enter-score">
             {match.completed ? 'Edit Score' : 'Enter Score'}
           </button>
         </div>

--- a/src/components/TournamentView.css
+++ b/src/components/TournamentView.css
@@ -66,6 +66,9 @@
   font-weight: 500;
   transition: all 0.3s ease;
   white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .btn-back {
@@ -179,6 +182,9 @@
   font-weight: 500;
   transition: all 0.2s ease;
   white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .btn-expand {
@@ -232,10 +238,20 @@
   cursor: pointer;
   transition: all 0.2s ease;
   user-select: none;
+  width: 100%;
+  border: none;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  appearance: none;
 }
 
 .round-header:hover {
   background: linear-gradient(135deg, #e9ecef 0%, #dee2e6 100%);
+}
+
+.round-header:active {
+  background: linear-gradient(135deg, #dfe3e7 0%, #d0d6dc 100%);
 }
 
 .round-header-left {
@@ -464,5 +480,41 @@
 
   .round-matches {
     padding: 12px;
+  }
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .round-header:hover {
+    background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+  }
+
+  .round-header {
+    padding: 22px 28px;
+  }
+
+  .round-toggle {
+    font-size: 20px;
+  }
+
+  .round-title {
+    font-size: 21px;
+  }
+
+  .round-time,
+  .round-progress {
+    font-size: 16px;
+  }
+
+  .btn-back,
+  .btn-edit,
+  .btn-report,
+  .btn-expand,
+  .btn-collapse {
+    font-size: 15px;
+  }
+
+  .btn-expand,
+  .btn-collapse {
+    padding: 12px 18px;
   }
 }

--- a/src/components/TournamentView.tsx
+++ b/src/components/TournamentView.tsx
@@ -123,7 +123,7 @@ const TournamentView: React.FC<TournamentViewProps> = ({
   return (
     <div className="tournament-view">
       <div className="tournament-header">
-        <button onClick={onBack} className="btn-back">
+        <button type="button" onClick={onBack} className="btn-back">
           ← Back to Setup
         </button>
         <div className="tournament-title">
@@ -136,14 +136,16 @@ const TournamentView: React.FC<TournamentViewProps> = ({
           </div>
         </div>
         <div className="header-actions">
-          <button 
-            onClick={handleEditTournament} 
+          <button
+            type="button"
+            onClick={handleEditTournament}
             className="btn-edit"
           >
             ✏️ Edit Tournament
           </button>
-          <button 
-            onClick={handleGenerateReport} 
+          <button
+            type="button"
+            onClick={handleGenerateReport}
             className="btn-report"
             disabled={completedMatches === 0}
           >
@@ -180,8 +182,8 @@ const TournamentView: React.FC<TournamentViewProps> = ({
         </div>
 
         <div className="round-controls">
-          <button onClick={expandAll} className="btn-expand">Expand All</button>
-          <button onClick={collapseAll} className="btn-collapse">Collapse All</button>
+          <button type="button" onClick={expandAll} className="btn-expand">Expand All</button>
+          <button type="button" onClick={collapseAll} className="btn-collapse">Collapse All</button>
         </div>
       </div>
 
@@ -195,13 +197,20 @@ const TournamentView: React.FC<TournamentViewProps> = ({
             const roundCompleted = round.matches.every(m => m.completed);
             const roundInProgress = round.matches.some(m => m.completed) && !roundCompleted;
             const isExpanded = expandedRounds.has(round.time);
+            const matchesId = `round-${roundIndex}-matches`;
 
             return (
-              <div 
-                key={round.time} 
+              <div
+                key={round.time}
                 className={`round-section ${roundCompleted ? 'completed' : ''} ${roundInProgress ? 'in-progress' : ''}`}
               >
-                <div className="round-header" onClick={() => toggleRound(round.time)}>
+                <button
+                  type="button"
+                  className="round-header"
+                  onClick={() => toggleRound(round.time)}
+                  aria-expanded={isExpanded}
+                  aria-controls={isExpanded ? matchesId : undefined}
+                >
                   <div className="round-header-left">
                     <span className="round-toggle">
                       {isExpanded ? '▼' : '▶'}
@@ -221,10 +230,10 @@ const TournamentView: React.FC<TournamentViewProps> = ({
                       <span className="round-badge pending-badge">Pending</span>
                     )}
                   </div>
-                </div>
+                </button>
 
                 {isExpanded && (
-                  <div className="round-matches">
+                  <div className="round-matches" id={matchesId}>
                     <div className="matches-grid">
                       {round.matches.map(match => (
                         <MatchCard


### PR DESCRIPTION
## Summary
- add global touch target sizing, focus outlines, and tap highlight adjustments to improve touch ergonomics
- enhance the configuration panel and score editor with numeric input modes, enter-key handling, and larger controls for coarse pointers
- update match cards and round headers to use accessible buttons with touch-specific styling for easier mobile interaction

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3ba7f6848832eada2b9f86be87df1