### PR TITLE
Refactor setup wizard and improve edit flows

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -112,6 +112,49 @@ code {
   transform: translateY(-2px);
 }
 
+.warning-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  padding: 16px;
+}
+
+.warning-modal {
+  background: white;
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 520px;
+  width: 100%;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.25);
+}
+
+.warning-modal h3 {
+  margin-bottom: 10px;
+  color: #b45309;
+}
+
+.warning-list {
+  margin: 0 0 12px 0;
+  padding-left: 18px;
+  color: #92400e;
+}
+
+.warning-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.warning-note {
+  margin-top: 8px;
+  color: #6b7280;
+}
+
 @media (max-width: 768px) {
   .app {
     padding: 16px;

--- a/src/components/ConfigPanel.css
+++ b/src/components/ConfigPanel.css
@@ -1,66 +1,69 @@
 .config-panel {
-  max-width: 900px;
-  margin: 0 auto;
+  max-width: 1024px;
+  margin: 0 auto 32px;
   padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.config-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .config-panel h1 {
-  text-align: center;
   color: #2c3e50;
-  margin-bottom: 20px;
+  margin: 0;
 }
 
-.quick-start {
-  text-align: center;
-  margin-bottom: 30px;
-}
-
-.btn-sample-data {
-  padding: 12px 24px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  color: white;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 16px;
-  font-weight: 600;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  transition: all 0.3s ease;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.btn-sample-data:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+.header-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .config-section {
   background: white;
-  border-radius: 8px;
+  border-radius: 10px;
   padding: 20px;
-  margin-bottom: 20px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
-.config-section h2 {
-  color: #34495e;
-  margin-top: 0;
-  margin-bottom: 20px;
-  border-bottom: 2px solid #3498db;
-  padding-bottom: 10px;
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.section-step-chip {
+  background: #eef5ff;
+  color: #1f63d0;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.section-description {
+  color: #6b7280;
+  margin: 6px 0 0;
 }
 
 .form-group {
-  margin-bottom: 15px;
+  margin-bottom: 16px;
 }
 
 .form-group label {
   display: block;
-  margin-bottom: 5px;
-  color: #555;
-  font-weight: 500;
+  margin-bottom: 6px;
+  color: #374151;
+  font-weight: 600;
 }
 
 .form-group input[type="text"],
@@ -68,394 +71,475 @@
 .form-group input[type="number"],
 .form-group select {
   width: 100%;
-  padding: 8px 12px;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  font-size: 14px;
-  box-sizing: border-box;
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 15px;
 }
 
-.form-group input[type="text"]:focus,
-.form-group input[type="time"]:focus,
-.form-group input[type="number"]:focus,
+.form-group input:focus,
 .form-group select:focus {
+  border-color: #3b82f6;
   outline: none;
-  border-color: #3498db;
-  box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
 }
 
 .field-description {
   font-size: 12px;
-  color: #888;
-  margin: 5px 0 0 0;
-  font-style: italic;
+  color: #6b7280;
+  margin-top: 6px;
 }
 
-.checkbox-group label {
-  display: flex;
-  align-items: center;
-  cursor: pointer;
+.field-error {
+  color: #b91c1c;
+  font-size: 13px;
+  margin-top: 6px;
 }
 
-.checkbox-group input[type="checkbox"] {
-  margin-right: 8px;
-  cursor: pointer;
-  width: auto;
-}
-
-.court-list,
-.players-list {
-  margin-bottom: 15px;
-}
-
-.court-item,
-.player-item {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px;
-  background: #f8f9fa;
-  border-radius: 4px;
-  margin-bottom: 8px;
-}
-
-.court-item span {
-  flex: 1;
-}
-
-.player-item .player-name-input {
-  flex: 1;
-  padding: 6px 10px;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-}
-
-.player-item .skill-level {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-}
-
-.player-item .skill-level label {
-  margin: 0;
-  font-size: 12px;
-  color: #666;
-}
-
-.skill-input {
-  width: 60px !important;
-  padding: 6px 8px !important;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-}
-
-.add-court,
-.add-player {
-  display: flex;
-  gap: 10px;
-}
-
-.add-court input,
-.add-player input {
-  flex: 1;
-  padding: 8px 12px;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-}
-
-.btn-add {
-  padding: 8px 16px;
-  background: #27ae60;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 15px;
-  font-weight: 600;
-  white-space: nowrap;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.btn-add:hover {
-  background: #229954;
-}
-
-.btn-remove {
-  padding: 6px 12px;
-  background: #e74c3c;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 14px;
-  white-space: nowrap;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.btn-remove:hover {
-  background: #c0392b;
-}
-
-.section-description {
-  color: #777;
-  font-size: 14px;
-  margin-top: -10px;
-  margin-bottom: 15px;
-}
-
-.doubles-info {
-  margin-bottom: 15px;
-}
-
-.doubles-pair-container {
-  background: #e8f4f8;
-  border: 2px solid #3498db;
+.inline-banner {
   border-radius: 8px;
-  padding: 12px;
+  padding: 12px 14px;
+  margin: 6px 0 10px;
+  border: 1px solid transparent;
+}
+
+.inline-banner.error {
+  background: #fef2f2;
+  border-color: #fecdd3;
+  color: #991b1b;
+}
+
+.inline-banner.warning {
+  background: #fffbeb;
+  border-color: #fef3c7;
+  color: #92400e;
+}
+
+.inline-banner.success {
+  background: #ecfdf3;
+  border-color: #bbf7d0;
+  color: #166534;
+}
+
+.info-banner {
+  background: #eef2ff;
+  color: #312e81;
+  padding: 12px 14px;
+  border-radius: 8px;
   margin-bottom: 12px;
 }
 
-.pair-label {
-  font-weight: 600;
-  color: #2c3e50;
-  margin-bottom: 8px;
-  font-size: 14px;
+.wizard-progress {
+  background: white;
+  border-radius: 10px;
+  padding: 10px 14px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+.wizard-progress-bar {
+  height: 6px;
+  background: linear-gradient(90deg, #6366f1, #22c55e);
+  border-radius: 999px;
+  margin-top: 10px;
+  transition: width 0.3s ease;
+}
+
+.wizard-steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px;
+}
+
+.wizard-step {
   display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: #f9fafb;
+}
+
+.wizard-step.completed {
+  background: #ecfdf3;
+  color: #166534;
+}
+
+.wizard-step.active {
+  border: 1px solid #3b82f6;
+  background: #eff6ff;
+}
+
+.wizard-step-index {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #e5e7eb;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+}
+
+.wizard-step-label span {
+  display: block;
+  font-weight: 700;
+  color: #111827;
+}
+
+.wizard-step-label small {
+  color: #6b7280;
+}
+
+.wizard-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+
+.wizard-nav-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.btn-primary,
+.btn-secondary,
+.btn-tertiary,
+.btn-sample-data {
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: none;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 15px;
+  min-height: var(--touch-target-size);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #2563eb, #22c55e);
+  color: white;
+}
+
+.btn-secondary {
+  background: #eef2ff;
+  color: #312e81;
+  border: 1px solid #c7d2fe;
+}
+
+.btn-tertiary {
+  background: #f3f4f6;
+  color: #374151;
+  border: 1px solid #e5e7eb;
+}
+
+.btn-sample-data {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+}
+
+.btn-primary:hover {
+  filter: brightness(0.98);
+}
+
+.btn-secondary:hover,
+.btn-tertiary:hover,
+.btn-sample-data:hover {
+  filter: brightness(0.97);
+}
+
+.btn-remove {
+  padding: 10px 12px;
+  background: #fee2e2;
+  color: #991b1b;
+  border: 1px solid #fecdd3;
+  border-radius: 8px;
+  cursor: pointer;
+  min-height: var(--touch-target-size);
+}
+
+.btn-remove:hover {
+  background: #fecdd3;
+}
+
+.grid-2 {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.inline-form {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.pill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.pill {
+  background: #f3f4f6;
+  border-radius: 999px;
+  padding: 6px 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pill-remove {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.label-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.label-hint {
+  color: #6b7280;
+  font-size: 13px;
+}
+
+.breaks-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.break-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #fef3c7;
+  border-left: 4px solid #f59e0b;
+  padding: 10px;
+  border-radius: 8px;
+}
+
+.empty-note {
+  background: #f9fafb;
+  border: 1px dashed #d1d5db;
+  padding: 10px;
+  border-radius: 8px;
+  color: #6b7280;
+}
+
+.stack-on-mobile {
+  flex-wrap: wrap;
+}
+
+.players-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.player-item,
+.player-item-in-pair {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 12px;
+}
+
+.player-item.has-error {
+  border-color: #fca5a5;
+}
+
+.player-name-input {
+  flex: 1;
+}
+
+.skill-level {
+  display: flex;
+  gap: 6px;
   align-items: center;
 }
 
-.pair-label::before {
-  content: "👥";
-  margin-right: 6px;
+.skill-input {
+  width: 70px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+}
+
+.add-player {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.add-player input[type="text"] {
+  flex: 1;
+}
+
+.doubles-pair-container {
+  background: #eef2ff;
+  border-radius: 10px;
+  padding: 12px;
+  border: 1px solid #c7d2fe;
+}
+
+.pair-label {
+  font-weight: 700;
+  margin-bottom: 8px;
+  color: #312e81;
 }
 
 .pair-players {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-}
-
-.player-item-in-pair {
-  display: flex;
-  align-items: center;
   gap: 10px;
-  padding: 8px;
-  background: white;
-  border-radius: 4px;
-  border: 1px solid #d0e8f2;
 }
 
-.player-item-in-pair .player-name-input {
-  flex: 1;
+.chip {
+  display: inline-flex;
+  align-items: center;
   padding: 6px 10px;
-  border: 1px solid #ddd;
-  border-radius: 4px;
+  background: #f1f5f9;
+  border-radius: 999px;
+  margin: 2px;
+  font-size: 14px;
 }
 
-.player-item-in-pair .skill-level {
-  display: flex;
-  align-items: center;
-  gap: 5px;
+.review-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
 }
 
-.player-item-in-pair .skill-level label {
-  margin: 0;
-  font-size: 12px;
-  color: #666;
+.review-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 12px;
+  background: #f9fafb;
 }
 
-.breaks-list {
-  margin-bottom: 15px;
-}
-
-.break-item {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px;
-  background: #fff3cd;
-  border-radius: 4px;
+.review-card h3 {
   margin-bottom: 8px;
-  border-left: 3px solid #ffc107;
 }
 
-.break-item span {
-  flex: 1;
-  font-weight: 500;
-  color: #856404;
+.review-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 6px;
 }
 
-.add-break {
+.review-players {
   display: flex;
-  gap: 10px;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
-.add-break input {
-  padding: 8px 12px;
-  border: 1px solid #ddd;
-  border-radius: 4px;
+.inline-form input,
+.add-player input,
+.add-player .skill-input {
+  min-height: var(--touch-target-size);
 }
 
 .break-duration-input {
-  width: 130px !important;
-  flex: 0 0 130px !important;
-}
-
-.start-button-container {
-  text-align: center;
-  margin-top: 30px;
-}
-
-.btn-start {
-  padding: 15px 40px;
-  background: #3498db;
-  color: white;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 18px;
-  font-weight: 600;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  transition: all 0.3s ease;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.btn-start:hover {
-  background: #2980b9;
-  transform: translateY(-2px);
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
-}
-
-.btn-start:active {
-  transform: translateY(0);
+  width: 160px;
 }
 
 @media (max-width: 900px) {
   .config-panel {
     padding: 16px;
   }
+}
 
-  .config-section {
-    padding: 18px;
+@media (max-width: 700px) {
+  .grid-2,
+  .grid-3 {
+    grid-template-columns: 1fr;
+  }
+
+  .wizard-steps {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 480px) {
   .config-panel {
-    padding: 14px 12px 24px;
+    padding: 14px 12px 20px;
   }
 
-  .config-panel h1 {
-    font-size: 26px;
-  }
-
-  .config-section {
-    padding: 16px;
-  }
-
-  .btn-sample-data {
-    width: 100%;
-  }
-
-  .court-item,
-  .player-item {
+  .wizard-nav,
+  .wizard-nav-actions,
+  .header-actions,
+  .inline-form,
+  .add-player,
+  .player-item,
+  .player-item-in-pair {
     flex-direction: column;
     align-items: stretch;
-    gap: 12px;
   }
 
-  .break-item {
-    flex-direction: row;
-    align-items: center;
-  }
-
-  .player-item .skill-level {
-    justify-content: space-between;
-  }
-
-  .skill-input {
-    width: 100% !important;
-    max-width: 90px;
-  }
-
-  .add-court,
-  .add-player {
-    flex-direction: column;
-  }
-
-  .add-break {
-    flex-direction: column;
-  }
-
-  .break-duration-input {
-    width: 100% !important;
-  }
-
-  .btn-add,
-  .btn-remove {
+  .wizard-nav-actions button,
+  .header-actions button,
+  .inline-form button,
+  .add-player button {
     width: 100%;
   }
 
-  .start-button-container {
-    margin-top: 24px;
+  .wizard-progress {
+    padding: 10px;
   }
 
-  .btn-start {
+  .wizard-step {
+    padding: 6px 8px;
+  }
+
+  .players-list .player-item,
+  .players-list .player-item-in-pair {
+    align-items: stretch;
+  }
+
+  .btn-primary,
+  .btn-secondary,
+  .btn-tertiary,
+  .btn-sample-data {
     width: 100%;
-    padding: 14px 18px;
-    font-size: 16px;
-  }
-}
-
-@media (max-width: 420px) {
-  .config-panel h1 {
-    font-size: 24px;
-  }
-
-  .form-group label {
-    font-size: 14px;
-  }
-
-  .btn-start {
-    font-size: 15px;
   }
 }
 
 @media (hover: none) and (pointer: coarse) {
-  .config-panel {
-    padding-bottom: 32px;
-  }
-
-  .form-group input[type="text"],
-  .form-group input[type="time"],
-  .form-group input[type="number"],
-  .form-group select,
-  .add-court input,
-  .add-player input,
-  .skill-input {
-    font-size: 16px;
-  }
-
+  .btn-primary,
+  .btn-secondary,
+  .btn-tertiary,
   .btn-sample-data,
-  .btn-add,
-  .btn-remove,
-  .btn-start {
+  input,
+  select {
     font-size: 16px;
-  }
-
-  .court-item,
-  .player-item {
-    padding: 12px;
-  }
-
-  .btn-add,
-  .btn-remove {
-    min-width: var(--touch-target-size);
   }
 }

--- a/src/components/ConfigPanel.tsx
+++ b/src/components/ConfigPanel.tsx
@@ -1,101 +1,239 @@
-import React, { useState } from 'react';
-import type { Player, TournamentConfig, ScheduledBreak } from '../types';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import type { Player, ScheduledBreak, TournamentConfig } from '../types';
+import { useToast } from './ToastContext';
 import './ConfigPanel.css';
 
-interface ConfigPanelProps {
-  onStartTournament: (config: TournamentConfig, players: Player[]) => void;
+type StepId = 'basics' | 'courts' | 'players' | 'review';
+
+interface Step {
+  id: StepId;
+  label: string;
+  description: string;
 }
 
-const ConfigPanel: React.FC<ConfigPanelProps> = ({ onStartTournament }) => {
-  const [config, setConfig] = useState<TournamentConfig>({
-    tournamentName: 'Tennis Tournament',
-    gameType: 'singles',
-    doublesPartnerMode: 'fixed',
-    scoringMode: 'sets',
-    courts: ['Court 1', 'Court 2'],
-    startTime: '09:00',
-    matchDuration: 60,
-    breakDuration: 0,
-    scheduledBreaks: [],
-    enforceNonRepeatingMatches: true,
-    enforceFairMatches: true,
-    allowBypass: true,
-  });
+interface ConfigPanelProps {
+  initialConfig: TournamentConfig;
+  initialPlayers: Player[];
+  mode?: 'new' | 'edit';
+  onStartTournament: (config: TournamentConfig, players: Player[]) => void;
+  onSaveConfigOnly?: (config: TournamentConfig, players: Player[]) => void;
+  onCancelEdit?: () => void;
+}
 
-  const [players, setPlayers] = useState<Player[]>([
-    { id: '1', name: 'Player 1', skillLevel: 5 },
-    { id: '2', name: 'Player 2', skillLevel: 5 },
-  ]);
+const steps: Step[] = [
+  { id: 'basics', label: 'Basics', description: 'Tournament details and pacing' },
+  { id: 'courts', label: 'Courts & Breaks', description: 'Where and when matches run' },
+  { id: 'players', label: 'Players', description: 'Rosters and skill levels' },
+  { id: 'review', label: 'Review', description: 'Confirm settings before generating' },
+];
 
+const ConfigPanel: React.FC<ConfigPanelProps> = ({
+  initialConfig,
+  initialPlayers,
+  mode = 'new',
+  onStartTournament,
+  onSaveConfigOnly,
+  onCancelEdit,
+}) => {
+  const { showToast } = useToast();
+  const [config, setConfig] = useState<TournamentConfig>(initialConfig);
+  const [players, setPlayers] = useState<Player[]>(initialPlayers);
   const [newPlayerName, setNewPlayerName] = useState('');
   const [newPlayerSkill, setNewPlayerSkill] = useState(5);
   const [courtInput, setCourtInput] = useState('');
   const [breakTime, setBreakTime] = useState('12:00');
   const [breakDuration, setBreakDuration] = useState(30);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [bannerErrors, setBannerErrors] = useState<string[]>([]);
+  const playerInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
 
-  const handleAddPlayer = () => {
-    if (newPlayerName.trim()) {
-      // Check for duplicate names
-      const duplicateName = players.find(
-        p => p.name.toLowerCase() === newPlayerName.trim().toLowerCase()
+  useEffect(() => {
+    setConfig(initialConfig);
+    setPlayers(initialPlayers);
+  }, [initialConfig, initialPlayers]);
+
+  const duplicateNames = useMemo(() => {
+    const seen = new Map<string, number>();
+    players.forEach(player => {
+      const key = player.name.trim().toLowerCase();
+      if (!key) return;
+      seen.set(key, (seen.get(key) || 0) + 1);
+    });
+    return new Set(
+      Array.from(seen.entries())
+        .filter(([, count]) => count > 1)
+        .map(([name]) => name)
+    );
+  }, [players]);
+
+  const updateErrors = (errors: Record<string, string>) => {
+    setFieldErrors(prev => ({ ...prev, ...errors }));
+    setBannerErrors(Object.values(errors));
+  };
+
+  const clearStepErrors = (stepId: StepId) => {
+    const keysByStep: Record<StepId, string[]> = {
+      basics: ['tournamentName', 'matchDuration', 'breakDuration'],
+      courts: ['courts'],
+      players: ['players', 'player-new'],
+      review: [],
+    };
+
+    setFieldErrors(prev => {
+      const copy = { ...prev };
+      keysByStep[stepId].forEach(key => delete copy[key]);
+      if (stepId === 'players') {
+        Object.keys(copy).forEach(key => {
+          if (key.startsWith('player-')) {
+            delete copy[key];
+          }
+        });
+      }
+      return copy;
+    });
+  };
+
+  const focusPlayerField = (playerId: string) => {
+    const input = playerInputRefs.current[playerId];
+    if (input) {
+      input.focus();
+      input.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  };
+
+  const validateBasics = () => {
+    const errors: Record<string, string> = {};
+    if (!config.tournamentName.trim()) {
+      errors.tournamentName = 'Give your tournament a name.';
+    }
+    if (config.matchDuration < 15) {
+      errors.matchDuration = 'Match duration must be at least 15 minutes.';
+    }
+    if (config.breakDuration < 0) {
+      errors.breakDuration = 'Break duration cannot be negative.';
+    }
+    return errors;
+  };
+
+  const validateCourts = () => {
+    const errors: Record<string, string> = {};
+    if (config.courts.length === 0) {
+      errors.courts = 'Add at least one court to schedule matches.';
+    }
+    return errors;
+  };
+
+  const validatePlayers = () => {
+    const errors: Record<string, string> = {};
+    if (players.length < 2) {
+      errors.players = 'Add at least 2 players to start.';
+    }
+    if (config.gameType === 'doubles' && players.length < 4) {
+      errors.players = 'Doubles needs at least 4 players.';
+    }
+    players.forEach(player => {
+      const key = player.name.trim().toLowerCase();
+      if (!player.name.trim()) {
+        errors[`player-${player.id}`] = 'Name cannot be empty.';
+      } else if (duplicateNames.has(key)) {
+        errors[`player-${player.id}`] = 'Duplicate name — choose a unique one.';
+      }
+    });
+    return errors;
+  };
+
+  const validateStep = (stepId: StepId) => {
+    switch (stepId) {
+      case 'basics':
+        return validateBasics();
+      case 'courts':
+        return validateCourts();
+      case 'players':
+        return validatePlayers();
+      default:
+        return {};
+    }
+  };
+
+  const runStepValidation = (stepId: StepId) => {
+    const errors = validateStep(stepId);
+    if (Object.keys(errors).length > 0) {
+      updateErrors(errors);
+      showToast('Please fix the highlighted items.', 'warning');
+      return false;
+    }
+    clearStepErrors(stepId);
+    setBannerErrors([]);
+    return true;
+  };
+
+  const handleNext = () => {
+    const stepId = steps[currentStep].id;
+    if (!runStepValidation(stepId)) return;
+    setCurrentStep(prev => Math.min(prev + 1, steps.length - 1));
+  };
+
+  const handleBack = () => {
+    setBannerErrors([]);
+    setCurrentStep(prev => Math.max(prev - 1, 0));
+  };
+
+  const handleGenerateTournament = () => {
+    const errors = steps.reduce<Record<string, string>>((acc, step) => {
+      return { ...acc, ...validateStep(step.id) };
+    }, {});
+
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      setBannerErrors(Object.values(errors));
+      const firstErroredStep = steps.findIndex(step =>
+        Object.keys(validateStep(step.id)).length > 0
       );
-      
-      if (duplicateName) {
-        alert(`⚠️ A player named "${newPlayerName.trim()}" already exists!\n\nPlease use a different name to avoid confusion.`);
-        return;
+      if (firstErroredStep >= 0) {
+        setCurrentStep(firstErroredStep);
       }
-
-      const newPlayer: Player = {
-        id: Date.now().toString(),
-        name: newPlayerName.trim(),
-        skillLevel: newPlayerSkill,
-      };
-      setPlayers([...players, newPlayer]);
-      setNewPlayerName('');
-      setNewPlayerSkill(5);
-    }
-  };
-
-  const handleRemovePlayer = (id: string) => {
-    setPlayers(players.filter(p => p.id !== id));
-  };
-
-  const handleUpdatePlayer = (id: string, field: keyof Player, value: string | number) => {
-    // If updating name, check for duplicates
-    if (field === 'name' && typeof value === 'string') {
-      const trimmedName = value.trim();
-      if (trimmedName) {
-        const duplicateName = players.find(
-          p => p.id !== id && p.name.toLowerCase() === trimmedName.toLowerCase()
-        );
-        
-        if (duplicateName) {
-          alert(`⚠️ A player named "${trimmedName}" already exists!\n\nPlease use a different name to avoid confusion.`);
-          return;
-        }
-      }
+      return;
     }
 
-    setPlayers(players.map(p => 
-      p.id === id ? { ...p, [field]: value } : p
-    ));
+    setFieldErrors({});
+    setBannerErrors([]);
+    onStartTournament(config, players);
+  };
+
+  const handleSaveWithoutRegenerate = () => {
+    if (!onSaveConfigOnly) return;
+    const errors = steps.reduce<Record<string, string>>((acc, step) => {
+      return { ...acc, ...validateStep(step.id) };
+    }, {});
+
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      setBannerErrors(Object.values(errors));
+      const firstErroredStep = steps.findIndex(step =>
+        Object.keys(validateStep(step.id)).length > 0
+      );
+      if (firstErroredStep >= 0) {
+        setCurrentStep(firstErroredStep);
+      }
+      return;
+    }
+
+    onSaveConfigOnly(config, players);
   };
 
   const handleAddCourt = () => {
-    if (courtInput.trim()) {
-      setConfig({
-        ...config,
-        courts: [...config.courts, courtInput.trim()],
-      });
-      setCourtInput('');
+    if (!courtInput.trim()) {
+      updateErrors({ courts: 'Enter a court name to add.' });
+      return;
     }
+    setConfig(prev => ({ ...prev, courts: [...prev.courts, courtInput.trim()] }));
+    setCourtInput('');
+    setBannerErrors([]);
   };
 
   const handleRemoveCourt = (index: number) => {
-    setConfig({
-      ...config,
-      courts: config.courts.filter((_, i) => i !== index),
-    });
+    setConfig(prev => ({ ...prev, courts: prev.courts.filter((_, i) => i !== index) }));
   };
 
   const handleAddScheduledBreak = () => {
@@ -104,36 +242,65 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({ onStartTournament }) => {
       time: breakTime,
       duration: breakDuration,
     };
-    setConfig({
-      ...config,
-      scheduledBreaks: [...config.scheduledBreaks, newBreak].sort((a, b) => a.time.localeCompare(b.time)),
-    });
-    setBreakTime('12:00');
-    setBreakDuration(30);
+    setConfig(prev => ({
+      ...prev,
+      scheduledBreaks: [...prev.scheduledBreaks, newBreak].sort((a, b) =>
+        a.time.localeCompare(b.time)
+      ),
+    }));
   };
 
   const handleRemoveScheduledBreak = (id: string) => {
-    setConfig({
-      ...config,
-      scheduledBreaks: config.scheduledBreaks.filter(b => b.id !== id),
-    });
+    setConfig(prev => ({
+      ...prev,
+      scheduledBreaks: prev.scheduledBreaks.filter(b => b.id !== id),
+    }));
   };
 
-  const handleStartTournament = () => {
-    if (players.length < 2) {
-      alert('Please add at least 2 players.');
+  const handleAddPlayer = () => {
+    if (!newPlayerName.trim()) {
+      updateErrors({ 'player-new': 'Enter a player name to add.' });
       return;
     }
-    if (config.courts.length === 0) {
-      alert('Please add at least one court.');
+    const key = newPlayerName.trim().toLowerCase();
+    if (duplicateNames.has(key)) {
+      const message = `"${newPlayerName.trim()}" already exists.`;
+      updateErrors({ 'player-new': message });
+      const existing = players.find(
+        p => p.name.trim().toLowerCase() === key
+      );
+      if (existing) {
+        focusPlayerField(existing.id);
+      }
       return;
     }
-    if (config.gameType === 'doubles' && players.length < 4) {
-      alert('Please add at least 4 players for doubles.');
-      return;
+    const newPlayer: Player = {
+      id: Date.now().toString(),
+      name: newPlayerName.trim(),
+      skillLevel: newPlayerSkill,
+    };
+    setPlayers(prev => [...prev, newPlayer]);
+    setNewPlayerName('');
+    setNewPlayerSkill(5);
+    setBannerErrors([]);
+  };
+
+  const handleRemovePlayer = (id: string) => {
+    setPlayers(prev => prev.filter(p => p.id !== id));
+  };
+
+  const handleUpdatePlayer = (id: string, field: keyof Player, value: string | number) => {
+    if (field === 'name' && typeof value === 'string') {
+      const trimmed = value.trim();
+      const key = trimmed.toLowerCase();
+      if (duplicateNames.has(key) && players.some(p => p.id !== id && p.name.trim().toLowerCase() === key)) {
+        updateErrors({ [`player-${id}`]: 'Duplicate name — choose a unique one.' });
+      }
     }
 
-    onStartTournament(config, players);
+    setPlayers(prev =>
+      prev.map(p => (p.id === id ? { ...p, [field]: value } : p))
+    );
   };
 
   const handleLoadSampleData = () => {
@@ -149,353 +316,573 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({ onStartTournament }) => {
     ];
 
     setPlayers(samplePlayers);
-    setConfig({
-      ...config,
+    setConfig(prev => ({
+      ...prev,
       tournamentName: 'Summer Championship 2024',
       courts: ['Center Court', 'Court 1', 'Court 2'],
-    });
+    }));
+    showToast('Sample data loaded. Adjust anything you like!', 'success');
   };
+
+  const renderStepContent = () => {
+    const stepId = steps[currentStep].id;
+
+    if (stepId === 'basics') {
+      return (
+        <>
+          <div className="form-group">
+            <label>Tournament Name</label>
+            <input
+              type="text"
+              value={config.tournamentName}
+              onChange={e => setConfig({ ...config, tournamentName: e.target.value })}
+              aria-invalid={Boolean(fieldErrors.tournamentName)}
+            />
+            {fieldErrors.tournamentName && (
+              <p className="field-error">{fieldErrors.tournamentName}</p>
+            )}
+          </div>
+
+          <div className="grid-2">
+            <div className="form-group">
+              <label>Game Type</label>
+              <select
+                value={config.gameType}
+                onChange={e =>
+                  setConfig({ ...config, gameType: e.target.value as 'singles' | 'doubles' })
+                }
+              >
+                <option value="singles">Singles</option>
+                <option value="doubles">Doubles</option>
+              </select>
+            </div>
+
+            {config.gameType === 'doubles' && (
+              <div className="form-group">
+                <label>Doubles Partner Mode</label>
+                <select
+                  value={config.doublesPartnerMode}
+                  onChange={e =>
+                    setConfig({
+                      ...config,
+                      doublesPartnerMode: e.target.value as 'fixed' | 'random-non-repeating',
+                    })
+                  }
+                >
+                  <option value="fixed">Fixed Partners</option>
+                  <option value="random-non-repeating">Random Non-Repeating</option>
+                </select>
+              </div>
+            )}
+          </div>
+
+          <div className="grid-2">
+            <div className="form-group">
+              <label>Scoring Mode</label>
+              <select
+                value={config.scoringMode}
+                onChange={e =>
+                  setConfig({ ...config, scoringMode: e.target.value as 'sets' | 'simple' })
+                }
+              >
+                <option value="sets">Sets-Based (Traditional Tennis)</option>
+                <option value="simple">Simple Score (Single Number)</option>
+              </select>
+              <p className="field-description">
+                {config.scoringMode === 'sets'
+                  ? 'Track games and sets (e.g., 6-4, 6-3)'
+                  : 'Track just the final score (e.g., 15-12)'}
+              </p>
+            </div>
+
+            <div className="form-group">
+              <label>Start Time</label>
+              <input
+                type="time"
+                value={config.startTime}
+                onChange={e => setConfig({ ...config, startTime: e.target.value })}
+              />
+            </div>
+          </div>
+
+          <div className="grid-3">
+            <div className="form-group">
+              <label>Match Duration (minutes)</label>
+              <input
+                type="number"
+                min="15"
+                max="180"
+                value={config.matchDuration}
+                onChange={e =>
+                  setConfig({ ...config, matchDuration: parseInt(e.target.value) || 60 })
+                }
+                inputMode="numeric"
+                pattern="[0-9]*"
+              />
+              {fieldErrors.matchDuration && (
+                <p className="field-error">{fieldErrors.matchDuration}</p>
+              )}
+            </div>
+
+            <div className="form-group">
+              <label>Break Between Matches (minutes)</label>
+              <input
+                type="number"
+                min="0"
+                max="60"
+                value={config.breakDuration}
+                onChange={e =>
+                  setConfig({ ...config, breakDuration: parseInt(e.target.value) || 0 })
+                }
+                inputMode="numeric"
+                pattern="[0-9]*"
+              />
+              {fieldErrors.breakDuration && (
+                <p className="field-error">{fieldErrors.breakDuration}</p>
+              )}
+            </div>
+
+            <div className="form-group checkbox-group">
+              <label>
+                <input
+                  type="checkbox"
+                  checked={config.allowBypass}
+                  onChange={e => setConfig({ ...config, allowBypass: e.target.checked })}
+                />
+                Allow bypass if constraints cannot be met
+              </label>
+              <p className="field-description">
+                When enabled, you can still generate even if scheduling warnings appear.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid-2">
+            <div className="form-group checkbox-group">
+              <label>
+                <input
+                  type="checkbox"
+                  checked={config.enforceNonRepeatingMatches}
+                  onChange={e =>
+                    setConfig({ ...config, enforceNonRepeatingMatches: e.target.checked })
+                  }
+                />
+                Enforce non-repeating matches
+              </label>
+            </div>
+            <div className="form-group checkbox-group">
+              <label>
+                <input
+                  type="checkbox"
+                  checked={config.enforceFairMatches}
+                  onChange={e => setConfig({ ...config, enforceFairMatches: e.target.checked })}
+                />
+                Enforce fair matches (everyone plays the same number)
+              </label>
+            </div>
+          </div>
+        </>
+      );
+    }
+
+    if (stepId === 'courts') {
+      return (
+        <>
+          <div className="form-group">
+            <label>Courts</label>
+            <div className="pill-list">
+              {config.courts.map((court, idx) => (
+                <div key={court + idx} className="pill">
+                  <span>{court}</span>
+                  <button
+                    type="button"
+                    className="pill-remove"
+                    onClick={() => handleRemoveCourt(idx)}
+                    aria-label={`Remove ${court}`}
+                  >
+                    ✕
+                  </button>
+                </div>
+              ))}
+            </div>
+            {fieldErrors.courts && <p className="field-error">{fieldErrors.courts}</p>}
+            <div className="inline-form">
+              <input
+                type="text"
+                placeholder="Court name"
+                value={courtInput}
+                onChange={e => setCourtInput(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    handleAddCourt();
+                  }
+                }}
+              />
+              <button type="button" className="btn-secondary" onClick={handleAddCourt}>
+                Add Court
+              </button>
+            </div>
+          </div>
+
+          <div className="form-group">
+            <div className="label-row">
+              <label>Scheduled Breaks (Optional)</label>
+              <span className="label-hint">Create lunch / rest windows</span>
+            </div>
+            <div className="breaks-list">
+              {config.scheduledBreaks.map(scheduledBreak => (
+                <div key={scheduledBreak.id} className="break-item">
+                  <span>
+                    ⏸️ {scheduledBreak.time} — {scheduledBreak.duration} min
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveScheduledBreak(scheduledBreak.id)}
+                    className="btn-remove"
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+              {config.scheduledBreaks.length === 0 && (
+                <div className="empty-note">No scheduled breaks yet.</div>
+              )}
+            </div>
+            <div className="inline-form stack-on-mobile">
+              <input type="time" value={breakTime} onChange={e => setBreakTime(e.target.value)} />
+              <input
+                type="number"
+                min="15"
+                max="120"
+                placeholder="Duration (min)"
+                value={breakDuration}
+                onChange={e => setBreakDuration(parseInt(e.target.value) || 30)}
+                className="break-duration-input"
+              />
+              <button type="button" onClick={handleAddScheduledBreak} className="btn-secondary">
+                Add Break
+              </button>
+            </div>
+          </div>
+        </>
+      );
+    }
+
+    if (stepId === 'players') {
+      const isFixedDoubles = config.gameType === 'doubles' && config.doublesPartnerMode === 'fixed';
+      return (
+        <>
+          <div className="label-row">
+            <h3 className="section-subtitle">Players</h3>
+            <span className="label-hint">Tap a name to edit</span>
+          </div>
+          {isFixedDoubles && (
+            <div className="info-banner">
+              Players are paired sequentially (1-2, 3-4, etc.) for fixed doubles teams.
+            </div>
+          )}
+          {fieldErrors.players && <div className="inline-banner error">{fieldErrors.players}</div>}
+
+          <div className="players-list">
+            {isFixedDoubles ? (
+              <>
+                {Array.from({ length: Math.ceil(players.length / 2) }, (_, pairIndex) => {
+                  const player1 = players[pairIndex * 2];
+                  const player2 = players[pairIndex * 2 + 1];
+
+                  return (
+                    <div key={`pair-${pairIndex}`} className="doubles-pair-container">
+                      <div className="pair-label">Team {pairIndex + 1}</div>
+                      <div className="pair-players">
+                        {[player1, player2].filter(Boolean).map(player => (
+                          <div key={player!.id} className="player-item-in-pair">
+                            <input
+                              ref={el => (playerInputRefs.current[player!.id] = el)}
+                              type="text"
+                              value={player!.name}
+                              onChange={e => handleUpdatePlayer(player!.id, 'name', e.target.value)}
+                              className={`player-name-input ${
+                                fieldErrors[`player-${player!.id}`] ? 'input-error' : ''
+                              }`}
+                              placeholder="Player name"
+                            />
+                            {fieldErrors[`player-${player!.id}`] && (
+                              <p className="field-error">{fieldErrors[`player-${player!.id}`]}</p>
+                            )}
+                            <div className="skill-level">
+                              <label>Skill:</label>
+                              <input
+                                type="number"
+                                min="1"
+                                max="10"
+                                value={player!.skillLevel || 5}
+                                onChange={e =>
+                                  handleUpdatePlayer(
+                                    player!.id,
+                                    'skillLevel',
+                                    parseInt(e.target.value) || 5
+                                  )
+                                }
+                                className="skill-input"
+                                inputMode="numeric"
+                                pattern="[0-9]*"
+                              />
+                            </div>
+                            <button
+                              type="button"
+                              onClick={() => handleRemovePlayer(player!.id)}
+                              className="btn-remove"
+                            >
+                              Remove
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  );
+                })}
+              </>
+            ) : (
+              players.map(player => (
+                <div
+                  key={player.id}
+                  className={`player-item ${fieldErrors[`player-${player.id}`] ? 'has-error' : ''}`}
+                >
+                  <input
+                    ref={el => (playerInputRefs.current[player.id] = el)}
+                    type="text"
+                    value={player.name}
+                    onChange={e => handleUpdatePlayer(player.id, 'name', e.target.value)}
+                    className="player-name-input"
+                    placeholder="Player name"
+                    aria-invalid={Boolean(fieldErrors[`player-${player.id}`])}
+                  />
+                  <div className="skill-level">
+                    <label>Skill:</label>
+                    <input
+                      type="number"
+                      min="1"
+                      max="10"
+                      value={player.skillLevel || 5}
+                      onChange={e =>
+                        handleUpdatePlayer(player.id, 'skillLevel', parseInt(e.target.value) || 5)
+                      }
+                      className="skill-input"
+                      inputMode="numeric"
+                      pattern="[0-9]*"
+                    />
+                  </div>
+                  <button type="button" onClick={() => handleRemovePlayer(player.id)} className="btn-remove">
+                    Remove
+                  </button>
+                  {fieldErrors[`player-${player.id}`] && (
+                    <p className="field-error">{fieldErrors[`player-${player.id}`]}</p>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+          <div className="add-player">
+            <input
+              type="text"
+              placeholder="Player name"
+              value={newPlayerName}
+              onChange={e => setNewPlayerName(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleAddPlayer();
+                }
+              }}
+              aria-invalid={Boolean(fieldErrors['player-new'])}
+            />
+            <input
+              type="number"
+              min="1"
+              max="10"
+              placeholder="Skill"
+              value={newPlayerSkill}
+              onChange={e => setNewPlayerSkill(parseInt(e.target.value) || 5)}
+              className="skill-input"
+              inputMode="numeric"
+              pattern="[0-9]*"
+            />
+            <button type="button" onClick={handleAddPlayer} className="btn-secondary">
+              Add Player
+            </button>
+          </div>
+          {fieldErrors['player-new'] && <p className="field-error">{fieldErrors['player-new']}</p>}
+        </>
+      );
+    }
+
+    return (
+      <div className="review-grid">
+        <div className="review-card">
+          <h3>Basics</h3>
+          <ul>
+            <li>
+              <strong>Name:</strong> {config.tournamentName}
+            </li>
+            <li>
+              <strong>Game:</strong> {config.gameType === 'doubles' ? 'Doubles' : 'Singles'}
+              {config.gameType === 'doubles' ? ` (${config.doublesPartnerMode})` : ''}
+            </li>
+            <li>
+              <strong>Scoring:</strong> {config.scoringMode === 'sets' ? 'Sets' : 'Simple'}
+            </li>
+            <li>
+              <strong>Start Time:</strong> {config.startTime}
+            </li>
+            <li>
+              <strong>Match Duration:</strong> {config.matchDuration} min
+            </li>
+            <li>
+              <strong>Between Matches:</strong> {config.breakDuration} min
+            </li>
+          </ul>
+        </div>
+
+        <div className="review-card">
+          <h3>Courts & Breaks</h3>
+          <ul>
+            <li>
+              <strong>Courts:</strong> {config.courts.join(', ')}
+            </li>
+            <li>
+              <strong>Scheduled Breaks:</strong>{' '}
+              {config.scheduledBreaks.length === 0
+                ? 'None'
+                : config.scheduledBreaks.map(b => `${b.time} (${b.duration}m)`).join(', ')}
+            </li>
+          </ul>
+        </div>
+
+        <div className="review-card">
+          <h3>Players ({players.length})</h3>
+          <div className="review-players">
+            {players.map(player => (
+              <span key={player.id} className="chip">
+                {player.name} · {player.skillLevel}/10
+              </span>
+            ))}
+          </div>
+          {config.gameType === 'doubles' && config.doublesPartnerMode === 'fixed' && (
+            <p className="field-description">
+              Fixed partners will be paired sequentially (1-2, 3-4, ...).
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  const renderProgress = (placement: 'top' | 'bottom') => (
+    <div className={`wizard-progress ${placement}`}>
+      <div className="wizard-steps">
+        {steps.map((step, index) => {
+          const active = index === currentStep;
+          const completed = index < currentStep;
+          return (
+            <div
+              key={step.id}
+              className={`wizard-step ${active ? 'active' : ''} ${completed ? 'completed' : ''}`}
+            >
+              <div className="wizard-step-index">{index + 1}</div>
+              <div className="wizard-step-label">
+                <span>{step.label}</span>
+                <small>{step.description}</small>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div
+        className="wizard-progress-bar"
+        style={{ width: `${((currentStep + 1) / steps.length) * 100}%` }}
+        aria-label={`Step ${currentStep + 1} of ${steps.length}`}
+      />
+    </div>
+  );
+
+  const renderNavigation = () => (
+    <div className="wizard-nav">
+      <button
+        type="button"
+        className="btn-tertiary"
+        onClick={handleBack}
+        disabled={currentStep === 0}
+      >
+        Back
+      </button>
+      <div className="wizard-nav-actions">
+        {currentStep < steps.length - 1 && (
+          <button type="button" className="btn-primary" onClick={handleNext}>
+            Next
+          </button>
+        )}
+        {currentStep === steps.length - 1 && (
+          <>
+            {onSaveConfigOnly && (
+              <button type="button" className="btn-secondary" onClick={handleSaveWithoutRegenerate}>
+                Save without regenerating
+              </button>
+            )}
+            <button type="button" className="btn-primary" onClick={handleGenerateTournament}>
+              Generate Tournament
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
 
   return (
     <div className="config-panel">
-      <h1>🎾 Tennis Tournament Generator</h1>
-
-      <div className="quick-start">
-        <button type="button" onClick={handleLoadSampleData} className="btn-sample-data">
-          🎯 Load Sample Data (Try it out!)
-        </button>
-      </div>
-
-      <div className="config-section">
-        <h2>Tournament Settings</h2>
-        
-        <div className="form-group">
-          <label>Tournament Name:</label>
-          <input
-            type="text"
-            value={config.tournamentName}
-            onChange={(e) => setConfig({ ...config, tournamentName: e.target.value })}
-          />
-        </div>
-
-        <div className="form-group">
-          <label>Game Type:</label>
-          <select
-            value={config.gameType}
-            onChange={(e) => setConfig({ ...config, gameType: e.target.value as 'singles' | 'doubles' })}
-          >
-            <option value="singles">Singles</option>
-            <option value="doubles">Doubles</option>
-          </select>
-        </div>
-
-        {config.gameType === 'doubles' && (
-          <div className="form-group">
-            <label>Doubles Partner Mode:</label>
-            <select
-              value={config.doublesPartnerMode}
-              onChange={(e) => setConfig({ ...config, doublesPartnerMode: e.target.value as 'fixed' | 'random-non-repeating' })}
-            >
-              <option value="fixed">Fixed Partners</option>
-              <option value="random-non-repeating">Random Non-Repeating Partners</option>
-            </select>
-          </div>
-        )}
-
-        <div className="form-group">
-          <label>Scoring Mode:</label>
-          <select
-            value={config.scoringMode}
-            onChange={(e) => setConfig({ ...config, scoringMode: e.target.value as 'sets' | 'simple' })}
-          >
-            <option value="sets">Sets-Based (Traditional Tennis)</option>
-            <option value="simple">Simple Score (Single Number)</option>
-          </select>
-          <p className="field-description">
-            {config.scoringMode === 'sets' 
-              ? 'Track games and sets (e.g., 6-4, 6-3)' 
-              : 'Track just the final score (e.g., 15-12)'}
-          </p>
-        </div>
-
-        <div className="form-group">
-          <label>Start Time:</label>
-          <input
-            type="time"
-            value={config.startTime}
-            onChange={(e) => setConfig({ ...config, startTime: e.target.value })}
-          />
-        </div>
-
-        <div className="form-group">
-          <label>Match Duration (minutes):</label>
-          <input
-            type="number"
-            min="15"
-            max="180"
-            value={config.matchDuration}
-            onChange={(e) => setConfig({ ...config, matchDuration: parseInt(e.target.value) || 60 })}
-            inputMode="numeric"
-            pattern="[0-9]*"
-            enterKeyHint="next"
-          />
-        </div>
-
-        <div className="form-group">
-          <label>Break Between Matches (minutes):</label>
-          <input
-            type="number"
-            min="0"
-            max="60"
-            value={config.breakDuration}
-            onChange={(e) => setConfig({ ...config, breakDuration: parseInt(e.target.value) || 0 })}
-            inputMode="numeric"
-            pattern="[0-9]*"
-            enterKeyHint="next"
-          />
-        </div>
-
-        <div className="form-group checkbox-group">
-          <label>
-            <input
-              type="checkbox"
-              checked={config.enforceNonRepeatingMatches}
-              onChange={(e) => setConfig({ ...config, enforceNonRepeatingMatches: e.target.checked })}
-            />
-            Enforce Non-Repeating Matches
-          </label>
-        </div>
-
-        <div className="form-group checkbox-group">
-          <label>
-            <input
-              type="checkbox"
-              checked={config.enforceFairMatches}
-              onChange={(e) => setConfig({ ...config, enforceFairMatches: e.target.checked })}
-            />
-            Enforce Fair Matches (everyone plays same number)
-          </label>
-        </div>
-
-        <div className="form-group checkbox-group">
-          <label>
-            <input
-              type="checkbox"
-              checked={config.allowBypass}
-              onChange={(e) => setConfig({ ...config, allowBypass: e.target.checked })}
-            />
-            Allow Bypass if Constraints Cannot Be Met
-          </label>
-        </div>
-      </div>
-
-      <div className="config-section">
-        <h2>Scheduled Breaks (Optional)</h2>
-        <p className="section-description">Add specific breaks at certain times (e.g., lunch break)</p>
-        <div className="breaks-list">
-          {config.scheduledBreaks.map((scheduledBreak) => (
-            <div key={scheduledBreak.id} className="break-item">
-              <span>⏸️ {scheduledBreak.time} - {scheduledBreak.duration} min</span>
-              <button type="button" onClick={() => handleRemoveScheduledBreak(scheduledBreak.id)} className="btn-remove">
-                Remove
-              </button>
-            </div>
-          ))}
-        </div>
-        <div className="add-break">
-          <input
-            type="time"
-            value={breakTime}
-            onChange={(e) => setBreakTime(e.target.value)}
-            enterKeyHint="next"
-          />
-          <input
-            type="number"
-            min="15"
-            max="120"
-            placeholder="Duration (min)"
-            value={breakDuration}
-            onChange={(e) => setBreakDuration(parseInt(e.target.value) || 30)}
-            className="break-duration-input"
-            inputMode="numeric"
-            pattern="[0-9]*"
-          />
-          <button type="button" onClick={handleAddScheduledBreak} className="btn-add">Add Break</button>
-        </div>
-      </div>
-
-      <div className="config-section">
-        <h2>Courts</h2>
-        <div className="court-list">
-          {config.courts.map((court, idx) => (
-            <div key={idx} className="court-item">
-              <span>{court}</span>
-              <button type="button" onClick={() => handleRemoveCourt(idx)} className="btn-remove">
-                Remove
-              </button>
-            </div>
-          ))}
-        </div>
-        <div className="add-court">
-          <input
-            type="text"
-            placeholder="Court name"
-            value={courtInput}
-            onChange={(e) => setCourtInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                handleAddCourt();
-              }
-            }}
-            enterKeyHint="done"
-          />
-          <button type="button" onClick={handleAddCourt} className="btn-add">Add Court</button>
-        </div>
-      </div>
-
-      <div className="config-section">
-        <h2>Players</h2>
-        {config.gameType === 'doubles' && config.doublesPartnerMode === 'fixed' && (
-          <div className="doubles-info">
-            <p className="section-description">
-              ℹ️ Players are paired sequentially (1-2, 3-4, etc.) for fixed doubles teams.
-            </p>
-          </div>
-        )}
-        <div className="players-list">
-          {config.gameType === 'doubles' && config.doublesPartnerMode === 'fixed' ? (
-            // Show players in pairs for fixed doubles
-            <>
-              {Array.from({ length: Math.ceil(players.length / 2) }, (_, pairIndex) => {
-                const player1 = players[pairIndex * 2];
-                const player2 = players[pairIndex * 2 + 1];
-                
-                return (
-                  <div key={`pair-${pairIndex}`} className="doubles-pair-container">
-                    <div className="pair-label">Team {pairIndex + 1}</div>
-                    <div className="pair-players">
-                      <div className="player-item-in-pair">
-                        <input
-                          type="text"
-                          value={player1.name}
-                          onChange={(e) => handleUpdatePlayer(player1.id, 'name', e.target.value)}
-                          className="player-name-input"
-                          placeholder="Player 1"
-                        />
-                        <div className="skill-level">
-                          <label>Skill:</label>
-                          <input
-                            type="number"
-                            min="1"
-                            max="10"
-                            value={player1.skillLevel || 5}
-                            onChange={(e) => handleUpdatePlayer(player1.id, 'skillLevel', parseInt(e.target.value) || 5)}
-                            className="skill-input"
-                            inputMode="numeric"
-                            pattern="[0-9]*"
-                          />
-                        </div>
-                        <button type="button" onClick={() => handleRemovePlayer(player1.id)} className="btn-remove">
-                          Remove
-                        </button>
-                      </div>
-                      {player2 && (
-                        <div className="player-item-in-pair">
-                          <input
-                            type="text"
-                            value={player2.name}
-                            onChange={(e) => handleUpdatePlayer(player2.id, 'name', e.target.value)}
-                            className="player-name-input"
-                            placeholder="Player 2"
-                          />
-                          <div className="skill-level">
-                            <label>Skill:</label>
-                            <input
-                              type="number"
-                              min="1"
-                              max="10"
-                              value={player2.skillLevel || 5}
-                              onChange={(e) => handleUpdatePlayer(player2.id, 'skillLevel', parseInt(e.target.value) || 5)}
-                              className="skill-input"
-                              inputMode="numeric"
-                              pattern="[0-9]*"
-                            />
-                          </div>
-                          <button type="button" onClick={() => handleRemovePlayer(player2.id)} className="btn-remove">
-                            Remove
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                );
-              })}
-            </>
-          ) : (
-            // Show players normally for singles or random doubles
-            players.map((player) => (
-              <div key={player.id} className="player-item">
-                <input
-                  type="text"
-                  value={player.name}
-                  onChange={(e) => handleUpdatePlayer(player.id, 'name', e.target.value)}
-                  className="player-name-input"
-                />
-                <div className="skill-level">
-                  <label>Skill:</label>
-                  <input
-                    type="number"
-                    min="1"
-                    max="10"
-                    value={player.skillLevel || 5}
-                    onChange={(e) => handleUpdatePlayer(player.id, 'skillLevel', parseInt(e.target.value) || 5)}
-                    className="skill-input"
-                    inputMode="numeric"
-                    pattern="[0-9]*"
-                  />
-                </div>
-                <button type="button" onClick={() => handleRemovePlayer(player.id)} className="btn-remove">
-                  Remove
-                </button>
-              </div>
-            ))
+      <div className="config-panel-header">
+        <h1>{mode === 'edit' ? 'Edit Setup' : '🎾 Tennis Tournament Generator'}</h1>
+        <div className="header-actions">
+          <button type="button" onClick={handleLoadSampleData} className="btn-sample-data">
+            🎯 Load Sample Data
+          </button>
+          {mode === 'edit' && onCancelEdit && (
+            <button type="button" className="btn-tertiary" onClick={onCancelEdit}>
+              Return to Tournament
+            </button>
           )}
         </div>
-        <div className="add-player">
-          <input
-            type="text"
-            placeholder="Player name"
-            value={newPlayerName}
-            onChange={(e) => setNewPlayerName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                handleAddPlayer();
-              }
-            }}
-            enterKeyHint="next"
-          />
-          <input
-            type="number"
-            min="1"
-            max="10"
-            placeholder="Skill"
-            value={newPlayerSkill}
-            onChange={(e) => setNewPlayerSkill(parseInt(e.target.value) || 5)}
-            className="skill-input"
-            inputMode="numeric"
-            pattern="[0-9]*"
-          />
-          <button type="button" onClick={handleAddPlayer} className="btn-add">Add Player</button>
-        </div>
       </div>
 
-      <div className="start-button-container">
-        <button type="button" onClick={handleStartTournament} className="btn-start">
-          Generate Tournament
-        </button>
+      {renderProgress('top')}
+
+      {bannerErrors.length > 0 && (
+        <div className="inline-banner error">
+          <strong>Please resolve:</strong>
+          <ul>
+            {bannerErrors.map((error, idx) => (
+              <li key={idx}>{error}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="config-section">
+        <div className="section-header">
+          <div>
+            <h2>{steps[currentStep].label}</h2>
+            <p className="section-description">{steps[currentStep].description}</p>
+          </div>
+          <div className="section-step-chip">
+            Step {currentStep + 1} of {steps.length}
+          </div>
+        </div>
+
+        <div className="step-content">{renderStepContent()}</div>
       </div>
+
+      {renderNavigation()}
+      {renderProgress('bottom')}
     </div>
   );
 };

--- a/src/components/EditTournamentModal.css
+++ b/src/components/EditTournamentModal.css
@@ -121,6 +121,11 @@
   background: #f8f9fa;
   border-radius: 6px;
   margin-bottom: 10px;
+  border: 1px solid transparent;
+}
+
+.player-edit-item.has-error {
+  border-color: #fca5a5;
 }
 
 .player-edit-item .player-name-input {
@@ -218,6 +223,10 @@
   border-radius: 8px;
   padding: 15px;
   background: #f8f9fa;
+}
+
+.match-edit-item.has-error {
+  border-color: #fca5a5;
 }
 
 .match-edit-header {

--- a/src/components/EditTournamentModal.tsx
+++ b/src/components/EditTournamentModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import type { Player, Match, TournamentConfig } from '../types';
 import './EditTournamentModal.css';
 
@@ -9,6 +9,15 @@ interface EditTournamentModalProps {
   onClose: () => void;
   onSave: (players: Player[], matches: Match[]) => void;
 }
+
+type BannerState =
+  | null
+  | {
+      type: 'error' | 'warning' | 'success';
+      message: string;
+      actionLabel?: string;
+      onAction?: () => void;
+    };
 
 const EditTournamentModal: React.FC<EditTournamentModalProps> = ({
   players,
@@ -22,60 +31,106 @@ const EditTournamentModal: React.FC<EditTournamentModalProps> = ({
   const [newPlayerName, setNewPlayerName] = useState('');
   const [newPlayerSkill, setNewPlayerSkill] = useState(5);
   const [activeTab, setActiveTab] = useState<'players' | 'matches'>('players');
+  const [banner, setBanner] = useState<BannerState>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
-  const handleAddPlayer = () => {
-    if (newPlayerName.trim()) {
-      const newPlayer: Player = {
-        id: Date.now().toString(),
-        name: newPlayerName.trim(),
-        skillLevel: newPlayerSkill,
-      };
-      setEditedPlayers([...editedPlayers, newPlayer]);
-      setNewPlayerName('');
-      setNewPlayerSkill(5);
-    }
+  const duplicateNames = useMemo(() => {
+    const seen = new Map<string, number>();
+    editedPlayers.forEach(p => {
+      const key = p.name.trim().toLowerCase();
+      if (!key) return;
+      seen.set(key, (seen.get(key) || 0) + 1);
+    });
+    return new Set(
+      Array.from(seen.entries())
+        .filter(([, count]) => count > 1)
+        .map(([name]) => name)
+    );
+  }, [editedPlayers]);
+
+  const resetBanner = () => setBanner(null);
+
+  const purgePlayerFromMatches = (playerId: string) => {
+    setEditedMatches(prev =>
+      prev.map(match => ({
+        ...match,
+        team1: match.team1.filter(p => p.id !== playerId),
+        team2: match.team2.filter(p => p.id !== playerId),
+      }))
+    );
+    setFieldErrors(current => {
+      const { [`player-${playerId}`]: _, ...rest } = current;
+      return rest;
+    });
+    setBanner({
+      type: 'success',
+      message: 'Removed the player from all matches. You can delete them now.',
+    });
   };
 
-  const handleRemovePlayer = (playerId: string) => {
-    // Check if player is in any match
-    const playerInMatches = editedMatches.some(
-      match => 
-        match.team1.some(p => p.id === playerId) || 
-        match.team2.some(p => p.id === playerId)
-    );
-
-    if (playerInMatches) {
-      alert('Cannot remove player who is assigned to matches. Please remove them from matches first.');
+  const handleAddPlayer = () => {
+    resetBanner();
+    if (!newPlayerName.trim()) {
+      setFieldErrors(prev => ({ ...prev, newPlayer: 'Enter a player name.' }));
+      setBanner({ type: 'error', message: 'Player name is required.' });
+      return;
+    }
+    const key = newPlayerName.trim().toLowerCase();
+    if (duplicateNames.has(key)) {
+      setFieldErrors(prev => ({ ...prev, newPlayer: 'Duplicate name — choose a unique one.' }));
+      setBanner({ type: 'error', message: 'Duplicate player names are not allowed.' });
       return;
     }
 
-    setEditedPlayers(editedPlayers.filter(p => p.id !== playerId));
+    const newPlayer: Player = {
+      id: Date.now().toString(),
+      name: newPlayerName.trim(),
+      skillLevel: newPlayerSkill,
+    };
+    setEditedPlayers(prev => [...prev, newPlayer]);
+    setNewPlayerName('');
+    setNewPlayerSkill(5);
+  };
+
+  const handleRemovePlayer = (playerId: string) => {
+    resetBanner();
+    const playerInMatches = editedMatches.some(
+      match => match.team1.some(p => p.id === playerId) || match.team2.some(p => p.id === playerId)
+    );
+
+    if (playerInMatches) {
+      setFieldErrors(prev => ({ ...prev, [`player-${playerId}`]: 'Remove from matches first.' }));
+      setBanner({
+        type: 'warning',
+        message: 'Player is assigned to matches. Remove them from matches first.',
+        actionLabel: 'Remove from matches',
+        onAction: () => purgePlayerFromMatches(playerId),
+      });
+      return;
+    }
+
+    setEditedPlayers(prev => prev.filter(p => p.id !== playerId));
+    setFieldErrors(prev => {
+      const { [`player-${playerId}`]: _, ...rest } = prev;
+      return rest;
+    });
   };
 
   const handleUpdatePlayer = (playerId: string, field: keyof Player, value: string | number) => {
-    setEditedPlayers(editedPlayers.map(p => 
-      p.id === playerId ? { ...p, [field]: value } : p
-    ));
-
-    // Update player info in all matches
-    setEditedMatches(editedMatches.map(match => ({
-      ...match,
-      team1: match.team1.map(p => 
-        p.id === playerId ? { ...p, [field]: value } : p
-      ),
-      team2: match.team2.map(p => 
-        p.id === playerId ? { ...p, [field]: value } : p
-      ),
-    })));
+    resetBanner();
+    setEditedPlayers(prev =>
+      prev.map(p => (p.id === playerId ? { ...p, [field]: value } : p))
+    );
   };
 
   const handleDeleteMatch = (matchId: string) => {
-    if (window.confirm('Are you sure you want to delete this match?')) {
-      setEditedMatches(editedMatches.filter(m => m.id !== matchId));
-    }
+    resetBanner();
+    setEditedMatches(prev => prev.filter(m => m.id !== matchId));
+    setBanner({ type: 'success', message: 'Match removed.' });
   };
 
   const handleAddMatch = () => {
+    resetBanner();
     const newMatch: Match = {
       id: `match-${Date.now()}`,
       court: config.courts[0] || 'Court 1',
@@ -84,77 +139,92 @@ const EditTournamentModal: React.FC<EditTournamentModalProps> = ({
       team2: [],
       completed: false,
     };
-    setEditedMatches([...editedMatches, newMatch]);
+    setEditedMatches(prev => [...prev, newMatch]);
   };
 
   const handleUpdateMatchPlayer = (
-    matchId: string, 
-    team: 'team1' | 'team2', 
-    index: number, 
+    matchId: string,
+    team: 'team1' | 'team2',
+    index: number,
     playerId: string
   ) => {
     const player = editedPlayers.find(p => p.id === playerId);
     if (!player) return;
 
-    setEditedMatches(editedMatches.map(match => {
-      if (match.id !== matchId) return match;
+    setEditedMatches(prev =>
+      prev.map(match => {
+        if (match.id !== matchId) return match;
+        const updatedTeam = [...match[team]];
+        if (index < updatedTeam.length) {
+          updatedTeam[index] = player;
+        } else {
+          updatedTeam.push(player);
+        }
+        return { ...match, [team]: updatedTeam };
+      })
+    );
+  };
 
-      const newMatch = { ...match };
-      const teamArray = [...newMatch[team]];
-      
-      if (index < teamArray.length) {
-        teamArray[index] = player;
-      } else {
-        teamArray.push(player);
+  const handleRemovePlayerFromMatch = (matchId: string, team: 'team1' | 'team2', index: number) => {
+    setEditedMatches(prev =>
+      prev.map(match => {
+        if (match.id !== matchId) return match;
+        return { ...match, [team]: match[team].filter((_, i) => i !== index) };
+      })
+    );
+  };
+
+  const handleUpdateMatchDetails = (matchId: string, field: 'court' | 'time', value: string) => {
+    setEditedMatches(prev =>
+      prev.map(match => (match.id === matchId ? { ...match, [field]: value } : match))
+    );
+  };
+
+  const validate = () => {
+    const errors: string[] = [];
+    const fieldMap: Record<string, string> = {};
+
+    if (editedPlayers.length < 2) {
+      errors.push('Tournament must have at least 2 players.');
+    }
+
+    editedPlayers.forEach(player => {
+      const key = player.name.trim().toLowerCase();
+      if (!player.name.trim()) {
+        fieldMap[`player-${player.id}`] = 'Name is required.';
+        errors.push('A player is missing a name.');
+      } else if (duplicateNames.has(key)) {
+        fieldMap[`player-${player.id}`] = 'Duplicate name — please make it unique.';
+        if (!errors.includes('Duplicate player names detected.')) {
+          errors.push('Duplicate player names detected.');
+        }
       }
-      
-      newMatch[team] = teamArray;
-      return newMatch;
-    }));
-  };
+    });
 
-  const handleRemovePlayerFromMatch = (
-    matchId: string,
-    team: 'team1' | 'team2',
-    index: number
-  ) => {
-    setEditedMatches(editedMatches.map(match => {
-      if (match.id !== matchId) return match;
+    const minPlayersPerTeam = config.gameType === 'singles' ? 1 : 2;
+    const invalidMatches = editedMatches.filter(
+      match => match.team1.length < minPlayersPerTeam || match.team2.length < minPlayersPerTeam
+    );
 
-      const newMatch = { ...match };
-      newMatch[team] = newMatch[team].filter((_, i) => i !== index);
-      return newMatch;
-    }));
-  };
+    if (invalidMatches.length > 0) {
+      errors.push(`${invalidMatches.length} match(es) need complete teams.`);
+      invalidMatches.forEach(match => {
+        fieldMap[`match-${match.id}`] = 'Add enough players to both teams.';
+      });
+    }
 
-  const handleUpdateMatchDetails = (
-    matchId: string,
-    field: 'court' | 'time',
-    value: string
-  ) => {
-    setEditedMatches(editedMatches.map(match =>
-      match.id === matchId ? { ...match, [field]: value } : match
-    ));
+    setFieldErrors(fieldMap);
+    if (errors.length > 0) {
+      setBanner({ type: 'error', message: errors[0] });
+      return false;
+    }
+
+    setBanner(null);
+    return true;
   };
 
   const handleSave = () => {
-    // Validation
-    if (editedPlayers.length < 2) {
-      alert('Tournament must have at least 2 players.');
-      return;
-    }
-
-    // Check if all matches have valid players
-    const invalidMatches = editedMatches.filter(match => {
-      const minPlayers = config.gameType === 'singles' ? 1 : 2;
-      return match.team1.length < minPlayers || match.team2.length < minPlayers;
-    });
-
-    if (invalidMatches.length > 0) {
-      alert(`${invalidMatches.length} match(es) have incomplete teams. Please fix or delete them.`);
-      return;
-    }
-
+    if (!validate()) return;
     onSave(editedPlayers, editedMatches);
   };
 
@@ -162,39 +232,64 @@ const EditTournamentModal: React.FC<EditTournamentModalProps> = ({
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-content" onClick={e => e.stopPropagation()}>
         <div className="modal-header">
           <h2>✏️ Edit Tournament</h2>
-          <button className="modal-close" onClick={onClose}>✕</button>
+          <button className="modal-close" onClick={onClose}>
+            ✕
+          </button>
         </div>
 
         <div className="modal-tabs">
           <button
             className={`tab-button ${activeTab === 'players' ? 'active' : ''}`}
-            onClick={() => setActiveTab('players')}
+            onClick={() => {
+              resetBanner();
+              setActiveTab('players');
+            }}
           >
             👥 Players ({editedPlayers.length})
           </button>
           <button
             className={`tab-button ${activeTab === 'matches' ? 'active' : ''}`}
-            onClick={() => setActiveTab('matches')}
+            onClick={() => {
+              resetBanner();
+              setActiveTab('matches');
+            }}
           >
             🎾 Matches ({editedMatches.length})
           </button>
         </div>
 
         <div className="modal-body">
+          {banner && (
+            <div className={`inline-banner ${banner.type}`}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10, flexWrap: 'wrap' }}>
+                <span>{banner.message}</span>
+                {banner.actionLabel && banner.onAction && (
+                  <button className="btn-secondary" onClick={banner.onAction}>
+                    {banner.actionLabel}
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+
           {activeTab === 'players' && (
             <div className="edit-section">
               <h3>Manage Players</h3>
               <div className="players-list-edit">
-                {editedPlayers.map((player) => (
-                  <div key={player.id} className="player-edit-item">
+                {editedPlayers.map(player => (
+                  <div
+                    key={player.id}
+                    className={`player-edit-item ${fieldErrors[`player-${player.id}`] ? 'has-error' : ''}`}
+                  >
                     <input
                       type="text"
                       value={player.name}
-                      onChange={(e) => handleUpdatePlayer(player.id, 'name', e.target.value)}
+                      onChange={e => handleUpdatePlayer(player.id, 'name', e.target.value)}
                       className="player-name-input"
+                      aria-invalid={Boolean(fieldErrors[`player-${player.id}`])}
                     />
                     <div className="skill-level">
                       <label>Skill:</label>
@@ -203,13 +298,18 @@ const EditTournamentModal: React.FC<EditTournamentModalProps> = ({
                         min="1"
                         max="10"
                         value={player.skillLevel || 5}
-                        onChange={(e) => handleUpdatePlayer(player.id, 'skillLevel', parseInt(e.target.value) || 5)}
+                        onChange={e =>
+                          handleUpdatePlayer(player.id, 'skillLevel', parseInt(e.target.value) || 5)
+                        }
                         className="skill-input"
                       />
                     </div>
                     <button onClick={() => handleRemovePlayer(player.id)} className="btn-remove-small">
                       Remove
                     </button>
+                    {fieldErrors[`player-${player.id}`] && (
+                      <p className="field-error">{fieldErrors[`player-${player.id}`]}</p>
+                    )}
                   </div>
                 ))}
               </div>
@@ -218,8 +318,9 @@ const EditTournamentModal: React.FC<EditTournamentModalProps> = ({
                   type="text"
                   placeholder="New player name"
                   value={newPlayerName}
-                  onChange={(e) => setNewPlayerName(e.target.value)}
-                  onKeyPress={(e) => e.key === 'Enter' && handleAddPlayer()}
+                  onChange={e => setNewPlayerName(e.target.value)}
+                  onKeyPress={e => e.key === 'Enter' && handleAddPlayer()}
+                  aria-invalid={Boolean(fieldErrors.newPlayer)}
                 />
                 <input
                   type="number"
@@ -227,11 +328,14 @@ const EditTournamentModal: React.FC<EditTournamentModalProps> = ({
                   max="10"
                   placeholder="Skill"
                   value={newPlayerSkill}
-                  onChange={(e) => setNewPlayerSkill(parseInt(e.target.value) || 5)}
+                  onChange={e => setNewPlayerSkill(parseInt(e.target.value) || 5)}
                   className="skill-input"
                 />
-                <button onClick={handleAddPlayer} className="btn-add-small">Add Player</button>
+                <button onClick={handleAddPlayer} className="btn-add-small">
+                  Add Player
+                </button>
               </div>
+              {fieldErrors.newPlayer && <p className="field-error">{fieldErrors.newPlayer}</p>}
             </div>
           )}
 
@@ -239,32 +343,39 @@ const EditTournamentModal: React.FC<EditTournamentModalProps> = ({
             <div className="edit-section">
               <div className="section-header">
                 <h3>Manage Matches</h3>
-                <button onClick={handleAddMatch} className="btn-add-match">+ Add Match</button>
+                <button onClick={handleAddMatch} className="btn-add-match">
+                  + Add Match
+                </button>
               </div>
               <div className="matches-list-edit">
-                {editedMatches.map((match) => (
-                  <div key={match.id} className="match-edit-item">
+                {editedMatches.map(match => (
+                  <div
+                    key={match.id}
+                    className={`match-edit-item ${fieldErrors[`match-${match.id}`] ? 'has-error' : ''}`}
+                  >
                     <div className="match-edit-header">
                       <div className="match-edit-details">
                         <select
                           value={match.court}
-                          onChange={(e) => handleUpdateMatchDetails(match.id, 'court', e.target.value)}
+                          onChange={e => handleUpdateMatchDetails(match.id, 'court', e.target.value)}
                         >
                           {config.courts.map(court => (
-                            <option key={court} value={court}>{court}</option>
+                            <option key={court} value={court}>
+                              {court}
+                            </option>
                           ))}
                         </select>
                         <input
                           type="time"
                           value={match.time}
-                          onChange={(e) => handleUpdateMatchDetails(match.id, 'time', e.target.value)}
+                          onChange={e => handleUpdateMatchDetails(match.id, 'time', e.target.value)}
                         />
                       </div>
                       <button onClick={() => handleDeleteMatch(match.id)} className="btn-delete-match">
                         Delete
                       </button>
                     </div>
-                    
+
                     <div className="match-teams-edit">
                       <div className="team-edit">
                         <label>Team 1:</label>
@@ -272,11 +383,13 @@ const EditTournamentModal: React.FC<EditTournamentModalProps> = ({
                           <div key={idx} className="player-select-row">
                             <select
                               value={match.team1[idx]?.id || ''}
-                              onChange={(e) => handleUpdateMatchPlayer(match.id, 'team1', idx, e.target.value)}
+                              onChange={e => handleUpdateMatchPlayer(match.id, 'team1', idx, e.target.value)}
                             >
                               <option value="">Select player...</option>
                               {editedPlayers.map(player => (
-                                <option key={player.id} value={player.id}>{player.name}</option>
+                                <option key={player.id} value={player.id}>
+                                  {player.name}
+                                </option>
                               ))}
                             </select>
                             {match.team1[idx] && (
@@ -290,20 +403,22 @@ const EditTournamentModal: React.FC<EditTournamentModalProps> = ({
                           </div>
                         ))}
                       </div>
-                      
+
                       <div className="vs-edit">VS</div>
-                      
+
                       <div className="team-edit">
                         <label>Team 2:</label>
                         {Array.from({ length: maxPlayersPerTeam }).map((_, idx) => (
                           <div key={idx} className="player-select-row">
                             <select
                               value={match.team2[idx]?.id || ''}
-                              onChange={(e) => handleUpdateMatchPlayer(match.id, 'team2', idx, e.target.value)}
+                              onChange={e => handleUpdateMatchPlayer(match.id, 'team2', idx, e.target.value)}
                             >
                               <option value="">Select player...</option>
                               {editedPlayers.map(player => (
-                                <option key={player.id} value={player.id}>{player.name}</option>
+                                <option key={player.id} value={player.id}>
+                                  {player.name}
+                                </option>
                               ))}
                             </select>
                             {match.team2[idx] && (
@@ -318,9 +433,10 @@ const EditTournamentModal: React.FC<EditTournamentModalProps> = ({
                         ))}
                       </div>
                     </div>
-                    
-                    {match.completed && (
-                      <div className="match-completed-badge">✓ Completed</div>
+
+                    {match.completed && <div className="match-completed-badge">✓ Completed</div>}
+                    {fieldErrors[`match-${match.id}`] && (
+                      <p className="field-error">{fieldErrors[`match-${match.id}`]}</p>
                     )}
                   </div>
                 ))}
@@ -330,8 +446,12 @@ const EditTournamentModal: React.FC<EditTournamentModalProps> = ({
         </div>
 
         <div className="modal-footer">
-          <button onClick={onClose} className="btn-cancel-modal">Cancel</button>
-          <button onClick={handleSave} className="btn-save-modal">Save Changes</button>
+          <button onClick={onClose} className="btn-cancel-modal">
+            Cancel
+          </button>
+          <button onClick={handleSave} className="btn-save-modal">
+            Save Changes
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/TournamentView.css
+++ b/src/components/TournamentView.css
@@ -378,6 +378,38 @@
   font-size: 18px;
 }
 
+.setup-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  padding: 16px;
+}
+
+.setup-modal {
+  background: white;
+  border-radius: 12px;
+  padding: 20px;
+  max-width: 420px;
+  width: 100%;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+.setup-modal h3 {
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.setup-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 12px;
+}
+
 @keyframes slideDown {
   from {
     opacity: 0;

--- a/src/components/TournamentView.tsx
+++ b/src/components/TournamentView.tsx
@@ -11,7 +11,8 @@ interface TournamentViewProps {
   players: Player[];
   config: TournamentConfig;
   warnings: string[];
-  onBack: () => void;
+  onEditSetup: () => void;
+  onStartFresh: () => void;
   onUpdateMatch: (matchId: string, match: Match) => void;
   onUpdateTournament: (players: Player[], matches: Match[]) => void;
 }
@@ -26,7 +27,8 @@ const TournamentView: React.FC<TournamentViewProps> = ({
   players,
   config,
   warnings,
-  onBack,
+  onEditSetup,
+  onStartFresh,
   onUpdateMatch,
   onUpdateTournament,
 }) => {
@@ -34,6 +36,7 @@ const TournamentView: React.FC<TournamentViewProps> = ({
   const [showEditModal, setShowEditModal] = useState(false);
   const [filterCourt, setFilterCourt] = useState<string>('all');
   const [expandedRounds, setExpandedRounds] = useState<Set<string>>(new Set());
+  const [showSetupOptions, setShowSetupOptions] = useState(false);
 
   const completedMatches = matches.filter(m => m.completed).length;
   const totalMatches = matches.length;
@@ -134,8 +137,8 @@ const TournamentView: React.FC<TournamentViewProps> = ({
   return (
     <div className="tournament-view">
       <div className="tournament-header">
-        <button type="button" onClick={onBack} className="btn-back">
-          ← Back to Setup
+        <button type="button" onClick={() => setShowSetupOptions(true)} className="btn-back">
+          ← Setup
         </button>
         <div className="tournament-title">
           <h1>{config.tournamentName}</h1>
@@ -147,11 +150,7 @@ const TournamentView: React.FC<TournamentViewProps> = ({
           </div>
         </div>
         <div className="header-actions">
-          <button
-            type="button"
-            onClick={handleEditTournament}
-            className="btn-edit"
-          >
+          <button type="button" onClick={handleEditTournament} className="btn-edit">
             ✏️ Edit Tournament
           </button>
           <button
@@ -283,6 +282,40 @@ const TournamentView: React.FC<TournamentViewProps> = ({
           onClose={() => setShowEditModal(false)}
           onSave={handleSaveEdit}
         />
+      )}
+
+      {showSetupOptions && (
+        <div className="setup-overlay">
+          <div className="setup-modal">
+            <h3>Return to setup</h3>
+            <p>Would you like to adjust the current setup or start fresh?</p>
+            <div className="setup-actions">
+              <button
+                type="button"
+                className="btn-secondary"
+                onClick={() => {
+                  setShowSetupOptions(false);
+                  onEditSetup();
+                }}
+              >
+                Edit current setup
+              </button>
+              <button
+                type="button"
+                className="btn-primary"
+                onClick={() => {
+                  setShowSetupOptions(false);
+                  onStartFresh();
+                }}
+              >
+                Start fresh
+              </button>
+              <button type="button" className="btn-tertiary" onClick={() => setShowSetupOptions(false)}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- convert the setup UI into a multi-step wizard with inline validation, touch-friendly actions, and a review step
- lift setup state into App with warning modal handling, an edit-setup path, and non-blocking setup options from the tournament view
- replace alerts in the edit modal with inline/banners and validation to keep users in-flow

## Testing
- not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dbab8bd40832eb8f70f904cfcc298)